### PR TITLE
feat: initial setup

### DIFF
--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -1,14 +1,14 @@
-name: DIY Steward
+name: Scala Center Steward
 
 on:
   schedule:
-    - cron: '0 */4 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:
   steward:
     runs-on: ubuntu-latest
-    name: DIY Steward
+    name: Scala Center Steward
     steps:
       - uses: actions/checkout@v3
           
@@ -16,14 +16,13 @@ jobs:
         id: generate-token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: 123456
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.SCALA_STEWARD_APP_ID }}
+          private_key: ${{ secrets.SCALA_STEWARD_APP_PRIVATE_KEY }}
 
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
-          author-email: 123456+your-app-name[bot]@users.noreply.github.com
-          author-name: your-app-name[bot]
-          github-app-id: 123456
-          github-app-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repos-file: 'repos.md'
+          author-email: 123456+scala-center-steward[bot]@users.noreply.github.com
+          author-name: scala-center-steward[bot]

--- a/README.md
+++ b/README.md
@@ -1,41 +1,15 @@
-# diy-steward
-Set up your very own Scala Steward!
+# Scala Center Steward
 
-1. Use this template to create a new repo.
-2. Create a new GitHub App.
-    - Personal app: https://github.com/settings/apps/new
-    - Org app: `https://github.com/organizations/[your-org]/settings/apps/new`
-3. You can disable the Webhook and set the App homepage to your new repo.
-4. Grant the App the following permissions:
-    - Actions: Read-only
-    - Contents: Read and write
-    - Metadata: Read-only
-    - Pull requests: Read and write
-    - Workflows: Read and write (this is required to support the sbt-github-actions plugin)
-5. Create the app. Note the app ID, we will need it later.
-6. Generate and download an App private key.
-7. Install the app on your repos. It _must_ be installed in this repo and it should also be installed on any repo you want steward updates on.
-    - Personal: `https://github.com/settings/apps/[your-app-name]/installations`
-    - Org: `https://github.com/organizations/[your-org]/settings/apps/[your-app-name]/installations`
-8. In this repo, set the secret `APP_PRIVATE_KEY` to the contents of the private key you downloaded.
-9. Finally, edit [`.github/workflows/steward.yml`](.github/workflows/steward.yml):
-    - Replace the 3 instances of `123456` with your app ID (see also [#1](https://github.com/armanbilge/diy-steward/issues/1))
-    - Replace the 2 instances of `your-app-name` with your app's name.
-    - Tweak the scheduling as you see fit. Default is ["At minute 0 past every 4th hour."](https://crontab.guru/#0_*/4_*_*_*)
-10. That's it! To manually trigger your new steward, navigate to the Actions tab on this repo, select the Scala Steward workflow, and click "Run Workflow".
+Runs the
+[scala-steward-action](https://github.com/scala-steward-org/scala-steward-action)
+daily to ensure dependencies across the Scala Center stay up to date.
 
-Please open issues or PRs with any improvements and fixes for this template. Thank you!
+PRs are sent in by ???
 
-## Running with repos.md
+## Adding a repo
 
-If you [use a repos.md file to list repositories](https://github.com/scala-steward-org/scala-steward-action#using-a-file-to-list-repositories), be sure to remove the `github-app-id` and `github-app-key` from the `scala-steward-action` configuration.  For example:
+Edit the [repos.md](./repos.md) file.
 
-```yaml
-      - name: Launch Scala Steward
-        uses: scala-steward-org/scala-steward-action@v2
-        with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          author-email: 123456+your-app-name[bot]@users.noreply.github.com
-          author-name: your-app-name[bot]
-          repos-file: 'repos.md'
-```
+**NOTE:** THis steward instance is only for `scalacenter` org repos. If you're
+outside of the org and would like to run Steward on your repos check out
+[diy-steward](https://github.com/armanbilge/diy-steward).

--- a/repos.md
+++ b/repos.md
@@ -1,0 +1,15 @@
+- scalacenter/bloop
+- scalacenter/bloop-config
+- scalacenter/effective-scala-slide-code
+- scalacenter/library-example
+- scalacenter/sbt-scalafix
+- scalacenter/sbt-scalafix-example
+- scalacenter/sbt-version-policy
+- scalacenter/scala3-migrate
+- scalacenter/scaladex
+- scalacenter/scalafix
+- scalacenter/scalafix.g8
+- scalacenter/scalajs-bundler
+- scalacenter/scala-3-migration-guide
+- scalacenter/scala-debug-adapter
+- scalacenter/scastie


### PR DESCRIPTION
Couple things left to do:

- [x] Remove scalacenter repos from public instance
- [x] Remove steward from repos that have it defined in their own CI
- [x] Ensure the `scala-steward-app` is "installed" on all the repos in the repo.md file (including this repo). I don't have access to https://github.com/organizations/scalacenter/settings/apps/scala-center-steward/installations so can't verify this. @julienrf you'll have to do this part.
- [x] Merge this in

EDIT: I'm going to change the order a bit for this. I'll confirm this works and then merge the other ones in.