### PR TITLE
Remove scala-3-migration-guide repo

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -10,6 +10,5 @@
 - scalacenter/scalafix
 - scalacenter/scalafix.g8
 - scalacenter/scalajs-bundler
-- scalacenter/scala-3-migration-guide
 - scalacenter/scala-debug-adapter
 - scalacenter/scastie


### PR DESCRIPTION
The Scala 3 migration guide no longer needs dependency updates.

(The repo has not yet been deprecated because I still want to track the migration status of the macro libraries)