### PR TITLE
fix: ensure Mill is available

### DIFF
--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -11,6 +11,9 @@ jobs:
     name: Scala Center Steward
     steps:
       - uses: actions/checkout@v3
+      - uses: jodersky/setup-mill@0.3.0
+        with:
+          mill-version: 0.10.9
           
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
So I sort of assumed the steward action took care of installing the
tools that it needed, but apparently not. This change ensures Mill is
available when Steward runs since currently it's failing on the
`bloop-config` repo because no global Mill is available.

refs: https://github.com/scala-steward-org/scala-steward/issues/2803
