### PR TITLE
chore: bump action back to v2

### DIFF
--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -19,7 +19,7 @@ jobs:
           private_key: ${{ secrets.SCALA_STEWARD_APP_PRIVATE_KEY }}
 
       - name: Launch Scala Steward
-        uses: scala-steward-org/scala-steward-action@mill
+        uses: scala-steward-org/scala-steward-action@v2
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           repos-file: 'repos.md'


### PR DESCRIPTION
Now that https://github.com/scala-steward-org/scala-steward-action/pull/414 is merged
and released we don't need to worry about installing Mill anymore since the action
does it.
