### PR TITLE
fix(ci): ensure job stays active if no changes for 60 days

### DIFF
--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -25,3 +25,8 @@ jobs:
           repos-file: 'repos.md'
           author-email: 111975575+scala-center-steward[bot]@users.noreply.github.com
           author-name: scala-center-steward[bot]
+
+      - uses: gautamkrishnar/keepalive-workflow@v1
+        with:
+          committer_username: scala-center-steward[bot]
+          committer_email: 111975575+scala-center-steward[bot]@users.noreply.github.com


### PR DESCRIPTION
If there are no changes jobs that are set up via crons go silent after
60 days. This is why we haven't been getting prs sent in. We use this
action in Scalameta to ensure that right before the 60 day hits a commit
is added to the repo. This will ensure steward continues to run.
