### PR TITLE
chore: Always run keepalive to make sure actions keep getting run

### DIFF
--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -27,6 +27,7 @@ jobs:
           author-name: scala-center-steward[bot]
 
       - uses: gautamkrishnar/keepalive-workflow@v1
+        if: always()
         with:
           committer_username: scala-center-steward[bot]
           committer_email: 111975575+scala-center-steward[bot]@users.noreply.github.com


### PR DESCRIPTION
It seems that scala steward might fail if one of the repos failed and keepalive would not be run.

Now, it should run always.